### PR TITLE
✨ feat: 암호화폐 및 거래소 명에 대한 필드 추가 & .env 적용

### DIFF
--- a/producer/src/api/binance.rs
+++ b/producer/src/api/binance.rs
@@ -1,20 +1,23 @@
 use reqwest::Error;
 use crate::models::market_data::MarketData;
-use crate::utils::parse_f64;  
+use crate::utils::{normalize_symbol, parse_f64};
+use std::env;
 
 pub async fn get_binance_ohlcv(symbol: &str) -> Result<MarketData, Error> {
-    let url = "https://api.binance.com/api/v3/ticker/24hr";
-    let client = reqwest::Client::new();
+    let url = env::var("BINANCE_API_URL").expect("BINANCE_API_URL 환경 변수를 설정하세요.");
 
+    let client = reqwest::Client::new();
     let response = client
-        .get(url)
+        .get(&url)
         .query(&[("symbol", symbol)])
         .send()
         .await?;
-
+        
     let binance_data: serde_json::Value = response.json().await?;
 
     let market_data = MarketData {
+        symbol: normalize_symbol(symbol).to_string(),
+        exchange_name: "Binance".to_string(),
         opening_price: parse_f64(&binance_data["openPrice"]),
         high_price: parse_f64(&binance_data["highPrice"]),
         low_price: parse_f64(&binance_data["lowPrice"]),

--- a/producer/src/api/bithumb.rs
+++ b/producer/src/api/bithumb.rs
@@ -1,17 +1,20 @@
 use reqwest::Error;
 use crate::models::market_data::MarketData;
-use crate::utils::parse_f64;  
+use crate::utils::{normalize_symbol, parse_f64};
+use std::env;
 
 pub async fn get_bithumb_ohlcv(symbol: &str) -> Result<MarketData, Error> {
+    let base_url = env::var("BITHUMB_API_URL").expect("BITHUMB_API_URL 환경 변수를 설정하세요.");
+
     // BTC-USDT에 대한 API가 없어, KRW-BTC 및 KRW-USDT의 데이터를 통해 환산
-    let url = format!("https://api.bithumb.com/v1/ticker?markets={}", symbol);
-    let krw_usdt_url = "https://api.bithumb.com/v1/ticker?markets=KRW-USDT";
-    
+    let url = format!("{}?markets={}", base_url, symbol);
+    let krw_usdt_url = format!("{}?markets=KRW-USDT", base_url);
+
     let client = reqwest::Client::new();
 
     // KRW-BTC와 KRW-USDT 데이터를 비동기적으로 가져옴
-    let response = client.get(url).send().await?;
-    let krw_usdt_response = client.get(krw_usdt_url).send().await?;
+    let response = client.get(&url).send().await?;
+    let krw_usdt_response = client.get(&krw_usdt_url).send().await?;
 
     let bithumb_data: serde_json::Value = response.json().await?;
     let krw_usdt_data: serde_json::Value = krw_usdt_response.json().await?;
@@ -24,6 +27,8 @@ pub async fn get_bithumb_ohlcv(symbol: &str) -> Result<MarketData, Error> {
     let crypto_usdt_price = krw_crypto_price / krw_usdt_price;
 
     let market_data = MarketData {
+        symbol: normalize_symbol(symbol).to_string(),
+        exchange_name: "Bithumb".to_string(),
         opening_price: parse_f64(&bithumb_data[0]["opening_price"]) / krw_usdt_price,
         high_price: parse_f64(&bithumb_data[0]["high_price"]) / krw_usdt_price,
         low_price: parse_f64(&bithumb_data[0]["low_price"]) / krw_usdt_price,

--- a/producer/src/api/upbit.rs
+++ b/producer/src/api/upbit.rs
@@ -1,20 +1,24 @@
 use reqwest::Error;
 use crate::models::market_data::MarketData;
-use crate::utils::parse_f64;  
+use crate::utils::{normalize_symbol, parse_f64};
+use std::env;
 
 pub async fn get_upbit_ohlcv(symbol: &str) -> Result<MarketData, Error> {
-    let url = format!("https://api.upbit.com/v1/ticker?markets={}", symbol);
-    let client = reqwest::Client::new();
+    let base_url = env::var("UPBIT_API_URL").expect("UPBIT_API_URL 환경 변수를 설정하세요.");
+    let url = format!("{}?markets={}", base_url, symbol);
 
+    let client = reqwest::Client::new();
     let response = client
         .get(&url)
         .send()
         .await?;
 
     let upbit_data: serde_json::Value = response.json().await?;
-    let upbit_data = &upbit_data[0];  
+    let upbit_data = &upbit_data[0];
 
     let market_data = MarketData {
+        symbol: normalize_symbol(symbol).to_string(),
+        exchange_name: "Upbit".to_string(),
         opening_price: parse_f64(&upbit_data["opening_price"]),
         high_price: parse_f64(&upbit_data["high_price"]),
         low_price: parse_f64(&upbit_data["low_price"]),

--- a/producer/src/kafka/producer.rs
+++ b/producer/src/kafka/producer.rs
@@ -1,10 +1,14 @@
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::Timeout;
+use std::env;
 
 pub fn create_producer() -> FutureProducer {
+    let kafka_bootstrap_servers = env::var("KAFKA_BOOTSTRAP_SERVERS")
+        .expect("KAFKA_BOOTSTRAP_SERVERS 환경 변수를 설정하세요.");
+
     ClientConfig::new()
-        .set("bootstrap.servers", "localhost:9092")
+        .set("bootstrap.servers", &kafka_bootstrap_servers)
         .create()
         .expect("Producer creation error")
 }

--- a/producer/src/main.rs
+++ b/producer/src/main.rs
@@ -2,8 +2,9 @@ mod utils;
 mod api;
 mod models;
 mod kafka;
-mod services;  
+mod services;
 
+use dotenv::dotenv;
 use tokio::time::{sleep, Duration};
 use rdkafka::producer::FutureProducer;
 use models::crypto_symbols::CryptoSymbols;
@@ -11,6 +12,8 @@ use services::service::fetch_and_send;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
+
     let producer: FutureProducer = kafka::producer::create_producer();
 
     let btc_symbols = CryptoSymbols::new("BTCUSDT", "BTC-USDT", "USDT-BTC", "KRW-BTC");

--- a/producer/src/models/market_data.rs
+++ b/producer/src/models/market_data.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarketData {
+    pub symbol: String,           
+    pub exchange_name: String,   
     pub opening_price: f64,
     pub high_price: f64,
     pub low_price: f64,

--- a/producer/src/services/service.rs
+++ b/producer/src/services/service.rs
@@ -1,5 +1,4 @@
 use crate::api::{binance, kucoin, upbit, bithumb};
-use crate::utils;
 use rdkafka::producer::FutureProducer;
 use serde_json;
 use crate::models::crypto_symbols::CryptoSymbols;
@@ -18,7 +17,7 @@ pub async fn fetch_and_send(
             kafka::producer::send_to_kafka(
                 producer,
                 "binance-topic",
-                utils::normalize_symbol(symbols.binance),
+                &market_data.symbol,  
                 payload.as_bytes(),
             )
             .await;
@@ -34,7 +33,7 @@ pub async fn fetch_and_send(
             kafka::producer::send_to_kafka(
                 producer,
                 "kucoin-topic",
-                utils::normalize_symbol(symbols.kucoin),
+                &market_data.symbol,  
                 payload.as_bytes(),
             )
             .await;
@@ -50,7 +49,7 @@ pub async fn fetch_and_send(
             kafka::producer::send_to_kafka(
                 producer,
                 "upbit-topic",
-                utils::normalize_symbol(symbols.upbit),
+                &market_data.symbol,  
                 payload.as_bytes(),
             )
             .await;
@@ -66,7 +65,7 @@ pub async fn fetch_and_send(
             kafka::producer::send_to_kafka(
                 producer,
                 "bithumb-topic",
-                utils::normalize_symbol(symbols.bithumb),
+                &market_data.symbol,  
                 payload.as_bytes(),
             )
             .await;


### PR DESCRIPTION
## producing data에 대한 symbol (ex: BTC), exchange_name (ex: Binance) 필드 추가
- Consumer(Spark) 단에서 토픽 명과 key를 추출하는 것보다 Producer (Kafka)단에서 필드를 추가하는 것이 효율적이라고 판단하여 필드 추가 
- 환경변수 (.env) 호출 로직 추가